### PR TITLE
added back to home, disabled # href in events

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             <li><a href="#team">Team</a></li>
             <li><a href="#about">About</a></li>
             <li class="dropdown">
-              <a href="#">Events ▾</a>
+              <a>Events ▾</a>
               <ul class="dropdown-content">
                 <li><a href="pages/workshops.html">Workshops</a></li>
                 <li>

--- a/pages/qiskit_fall_fest_2025.html
+++ b/pages/qiskit_fall_fest_2025.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Qiskit Fall Fest - UC Quantum Club</title>
     <link rel="stylesheet" href="../style.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
   </head>
   <body>
     <header>
@@ -13,6 +17,9 @@
           <img src="../Images/logo.jpg" alt="Quantum Club Logo" class="logo" />
         </div>
         <nav>
+          <div class="menu-icon" onclick="toggleMenu()">
+            <i class="fas fa-bars"></i>
+          </div>
           <ul id="nav-links">
             <li><a href="../index.html">← Back to Home</a></li>
           </ul>
@@ -33,9 +40,9 @@
         <p>
           The Qiskit Fall Fest is a global series of quantum computing events
           hosted by student-led organizations and supported by IBM Quantum. At
-          University of Calgary Quantum Club, our Fall Fest brings together students, researchers,
-          and industry professionals to learn, collaborate, and innovate with
-          Qiskit and quantum technologies.
+          University of Calgary Quantum Club, our Fall Fest brings together
+          students, researchers, and industry professionals to learn,
+          collaborate, and innovate with Qiskit and quantum technologies.
         </p>
       </section>
 
@@ -62,8 +69,8 @@
           >.
         </p>
         <p>
-          Can't attend our event? You can still become a Quantum Club member
-          and participate in future events by joining our Discord!
+          Can't attend our event? You can still become a Quantum Club member and
+          participate in future events by joining our Discord!
         </p>
         <h2>Contact Us</h2>
         <p>
@@ -93,5 +100,6 @@
     <footer>
       <p>&copy; 2025 UC Quantum Club. All rights reserved.</p>
     </footer>
+    <script src="../script.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -50,6 +50,7 @@ nav {
     flex: 1;
     display: flex;
     justify-content: flex-end;
+    padding-right: 10px
 }
 
 .menu-icon {


### PR DESCRIPTION
1. Added back to home in Qiskit Fall fest page
2. Removed section navigation for events submenu 